### PR TITLE
Add create_quote MCP tool (FastSpring Quotes API)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,10 @@ import {
   accountsToolDefinitions,
   type AccountsToolsDeps,
 } from "./tools/accounts.tools.js";
+import {
+  quotesToolDefinitions,
+  type QuotesToolsDeps,
+} from "./tools/quotes.tools.js";
 import { startStdioServer } from "./transports/stdio.js";
 import { startHttpServer, type McpServerFactory } from "./transports/http.js";
 import { z } from "zod";
@@ -32,43 +36,56 @@ const SERVER_VERSION = "1.0.0";
 // Zod → JSON Schema helpers
 // ---------------------------------------------------------------------------
 
-function zSchemaToJsonSchema(schema: z.ZodType): Record<string, unknown> {
-  const def = (
-    schema as {
-      _def?: {
-        typeName?: string;
-        schema?: z.ZodType;
-        innerType?: z.ZodType;
-      };
+// Extracts a ZodType's raw _def, typed broadly enough for all our introspection needs.
+type ZodDef = {
+  typeName?: string;
+  schema?: z.ZodType;       // ZodEffects inner schema
+  innerType?: z.ZodType;    // ZodOptional / ZodDefault inner type
+  type?: z.ZodType;         // ZodArray element type
+  values?: Record<string, unknown>; // ZodNativeEnum values map
+  description?: string;
+};
+
+function getDef(schema: z.ZodType): ZodDef {
+  return (schema as unknown as { _def: ZodDef })._def ?? {};
+}
+
+/**
+ * Unwraps wrapper types (ZodOptional, ZodDefault, ZodEffects / ZodPreprocess)
+ * until we reach a concrete type, and reports whether the field was optional.
+ */
+function unwrap(schema: z.ZodType): { inner: z.ZodType; optional: boolean } {
+  let optional = false;
+  let cur = schema;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const d = getDef(cur);
+    if (d.typeName === "ZodOptional" || d.typeName === "ZodDefault") {
+      optional = true;
+      cur = d.innerType!;
+    } else if (d.typeName === "ZodEffects" && d.schema) {
+      cur = d.schema;
+    } else {
+      break;
     }
-  )._def;
-  if (!def) return { type: "object", properties: {} };
-  if (def.typeName === "ZodEffects" && def.schema) {
-    return zSchemaToJsonSchema(def.schema);
   }
-  if (def.typeName === "ZodObject") {
-    const shape = (schema as z.ZodObject<z.ZodRawShape>).shape;
+  return { inner: cur, optional };
+}
+
+function zSchemaToJsonSchema(schema: z.ZodType): Record<string, unknown> {
+  const { inner } = unwrap(schema);
+  const d = getDef(inner);
+
+  if (!d.typeName) return { type: "object", properties: {} };
+
+  if (d.typeName === "ZodObject") {
+    const shape = (inner as z.ZodObject<z.ZodRawShape>).shape;
     const properties: Record<string, unknown> = {};
     const required: string[] = [];
-    for (const [key, value] of Object.entries(shape)) {
-      const sub = value as z.ZodType;
-      const subDef = (
-        sub as {
-          _def?: {
-            typeName?: string;
-            innerType?: z.ZodType;
-            schema?: z.ZodType;
-          };
-        }
-      )._def;
-      const isOptional =
-        subDef?.typeName === "ZodOptional" ||
-        subDef?.typeName === "ZodDefault";
-      let inner: z.ZodType | undefined = isOptional ? subDef?.innerType : sub;
-      if (inner && subDef?.typeName === "ZodEffects" && subDef?.schema)
-        inner = subDef.schema;
-      if (inner) properties[key] = zodTypeToJsonSchema(inner);
-      if (!isOptional) required.push(key);
+    for (const [key, field] of Object.entries(shape)) {
+      const { inner: fieldInner, optional } = unwrap(field as z.ZodType);
+      properties[key] = zodTypeToJsonSchema(fieldInner);
+      if (!optional) required.push(key);
     }
     return {
       type: "object",
@@ -76,19 +93,36 @@ function zSchemaToJsonSchema(schema: z.ZodType): Record<string, unknown> {
       required: required.length > 0 ? required : undefined,
     };
   }
-  if (def.typeName === "ZodString") return { type: "string" };
-  if (def.typeName === "ZodNumber") return { type: "number" };
-  if (def.typeName === "ZodBoolean") return { type: "boolean" };
-  if (def.typeName === "ZodArray") return { type: "array" };
+
+  if (d.typeName === "ZodArray") {
+    const elementType = d.type!;
+    return { type: "array", items: zodTypeToJsonSchema(elementType) };
+  }
+
+  if (d.typeName === "ZodString") return { type: "string" };
+  if (d.typeName === "ZodNumber") return { type: "number" };
+  if (d.typeName === "ZodBoolean") return { type: "boolean" };
+
+  if (d.typeName === "ZodNativeEnum" && d.values) {
+    const enumValues = Object.values(d.values).filter(
+      (v) => typeof v === "string" || typeof v === "number"
+    );
+    return { type: typeof enumValues[0] === "number" ? "integer" : "string", enum: enumValues };
+  }
+
+  if (d.typeName === "ZodEnum") {
+    const enumDef = getDef(inner) as ZodDef & { options?: unknown[] };
+    return { type: "string", enum: enumDef.options ?? [] };
+  }
+
   return { type: "object", properties: {} };
 }
 
 function zodTypeToJsonSchema(zodType: z.ZodType): Record<string, unknown> {
-  const def = (zodType as { _def?: { typeName?: string; description?: string } })
-    ._def;
+  // Capture description from the original (possibly wrapped) type before unwrapping.
+  const topDef = getDef(zodType);
   const base = zSchemaToJsonSchema(zodType);
-  if (def?.description)
-    (base as Record<string, unknown>).description = def.description;
+  if (topDef.description) base.description = topDef.description;
   return base;
 }
 
@@ -257,6 +291,7 @@ async function main(): Promise<void> {
       accounts: accountsDeps,
       orders: ordersDeps,
     };
+    const quotesDeps: QuotesToolsDeps = { http };
 
     const allToolDefs: ToolDef[] = [
       ...ordersToolDefinitions.map((t) => ({
@@ -279,6 +314,13 @@ async function main(): Promise<void> {
         inputSchema: t.inputSchema,
         handler: t.handler as ToolDef["handler"],
         deps: t.depsKey === "both" ? accountsToolsDeps : accountsDeps,
+      })),
+      ...quotesToolDefinitions.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+        handler: t.handler as ToolDef["handler"],
+        deps: quotesDeps,
       })),
     ];
 

--- a/src/services/quotes.service.ts
+++ b/src/services/quotes.service.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * This software is licensed under AGPL v3. For commercial licensing, see COMMERCIAL_LICENSE.md.
+ */
+
+import type { AxiosInstance } from "axios";
+import type {
+  CreateQuoteRequest,
+  CreateQuoteResponse,
+} from "../types/quotes.types.js";
+
+export interface QuotesServiceDeps {
+  http: AxiosInstance;
+}
+
+/**
+ * Creates a new quote via POST /quotes.
+ *
+ * The returned `quoteUrl` is a permanent link to the FastSpring storefront
+ * where the buyer can review line items, see VAT/tax breakdown, and complete
+ * payment. The quote is visible in the FastSpring dashboard immediately after
+ * creation.
+ */
+export async function createQuote(
+  deps: QuotesServiceDeps,
+  request: CreateQuoteRequest
+): Promise<CreateQuoteResponse> {
+  try {
+    const response = await deps.http.post<CreateQuoteResponse>(
+      "/quotes",
+      request
+    );
+    const result = response.data;
+    return result;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/src/tools/quotes.tools.ts
+++ b/src/tools/quotes.tools.ts
@@ -1,0 +1,400 @@
+/**
+ * @license
+ * This software is licensed under AGPL v3. For commercial licensing, see COMMERCIAL_LICENSE.md.
+ */
+
+import { z } from "zod";
+import * as quotesService from "../services/quotes.service.js";
+import type { QuotesServiceDeps } from "../services/quotes.service.js";
+import { FastSpringError } from "../utils/errors.js";
+import { QuoteFulfillmentTerm } from "../types/quotes.types.js";
+import type {
+  CreateQuoteRequest,
+  QuoteRequestItem,
+  QuoteRecipient,
+  QuoteRecipientAddress,
+  QuoteTag,
+} from "../types/quotes.types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const trimString = (s: string) => s.trim();
+const toUpper = (s: string) => s.toUpperCase();
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+const QuoteItemSchema = z
+  .object({
+    product: z
+      .string()
+      .min(1, "product path is required")
+      .transform(trimString)
+      .describe(
+        "FastSpring product path (SKU) as configured in the catalog, e.g. " +
+          '"my-annual-subscription". Must already exist in FastSpring.'
+      ),
+    quantity: z
+      .number()
+      .int()
+      .min(1, "quantity must be at least 1")
+      .optional()
+      .describe(
+        "Number of units to include in the quote. Defaults to 1 when omitted."
+      ),
+    unitListPrice: z
+      .number()
+      .min(0, "unitListPrice must be non-negative")
+      .optional()
+      .describe(
+        "Override the catalog list price per unit in the quote's base currency. " +
+          "When omitted the current catalog price is used."
+      ),
+  })
+  .describe("A single product line item to include in the quote.");
+
+const QuoteRecipientSchema = z
+  .object({
+    first: z
+      .string()
+      .min(1, "recipient first name is required")
+      .max(255)
+      .transform(trimString)
+      .describe("Buyer's first name."),
+    last: z
+      .string()
+      .min(1, "recipient last name is required")
+      .max(255)
+      .transform(trimString)
+      .describe("Buyer's last name."),
+    email: z
+      .preprocess(
+        (val) => (typeof val === "string" ? val.trim() : val),
+        z.string().email()
+      )
+      .describe("Buyer's email address. Must be a valid email."),
+    company: z
+      .string()
+      .max(255)
+      .transform(trimString)
+      .optional()
+      .describe("Buyer's company name (optional)."),
+    phone: z
+      .string()
+      .max(255)
+      .transform(trimString)
+      .optional()
+      .describe("Buyer's phone number in any format (optional)."),
+  })
+  .describe("Buyer contact information.");
+
+const QuoteRecipientAddressSchema = z
+  .object({
+    country: z
+      .string()
+      .length(2, "country must be a 2-letter ISO 3166-1 alpha-2 code")
+      .transform(toUpper)
+      .describe(
+        "2-letter ISO 3166-1 alpha-2 country code, e.g. GB, US, DE. Required."
+      ),
+    postalCode: z
+      .string()
+      .max(255)
+      .transform(trimString)
+      .optional()
+      .describe(
+        "Postal or ZIP code. Optional — omit or leave empty when not applicable."
+      ),
+    addressLine1: z
+      .string()
+      .max(255)
+      .transform(trimString)
+      .optional()
+      .describe("First line of the street address (optional)."),
+    addressLine2: z
+      .string()
+      .max(255)
+      .transform(trimString)
+      .optional()
+      .describe("Second line of the street address (optional)."),
+    city: z
+      .string()
+      .max(255)
+      .transform(trimString)
+      .optional()
+      .describe("City or municipality (optional)."),
+    region: z
+      .string()
+      .max(255)
+      .transform(trimString)
+      .optional()
+      .describe("State, province, or region (optional)."),
+  })
+  .describe("Billing address for the quote recipient.");
+
+const QuoteTagSchema = z
+  .object({
+    key: z
+      .string()
+      .min(1)
+      .transform(trimString)
+      .describe("Tag key/name."),
+    value: z
+      .string()
+      .transform(trimString)
+      .describe("Tag value."),
+  })
+  .describe(
+    "A key-value tag. Note: quotes use an array of tag objects (not a flat map)."
+  );
+
+/**
+ * Input schema for the create_quote MCP tool.
+ *
+ * Only `name`, `items`, `recipient`, and `recipientAddress` (with `country`) are
+ * required. Everything else is optional.
+ */
+export const CreateQuoteSchema = z.object({
+  name: z
+    .string()
+    .min(1, "name is required")
+    .max(255)
+    .transform(trimString)
+    .describe(
+      "Internal label for this quote — shown in the FastSpring dashboard and " +
+        "on the quote document sent to the buyer. Required."
+    ),
+
+  items: z
+    .array(QuoteItemSchema)
+    .min(1, "at least one item is required")
+    .describe(
+      "One or more products to include in the quote. " +
+        "Each item must reference a valid FastSpring product SKU. Required."
+    ),
+
+  recipient: QuoteRecipientSchema.describe(
+    "Buyer contact details. first, last, and email are required."
+  ),
+
+  recipientAddress: QuoteRecipientAddressSchema.describe(
+    "Billing address for the buyer. country (2-letter ISO code) is required."
+  ),
+
+  // ---  Optional fields  ---
+
+  coupon: z
+    .string()
+    .max(255)
+    .transform(trimString)
+    .optional()
+    .describe("Coupon code to apply to the quote (optional), e.g. SAVE20."),
+
+  currency: z
+    .string()
+    .length(3, "currency must be a 3-letter ISO 4217 code")
+    .transform(toUpper)
+    .optional()
+    .describe(
+      "3-letter ISO 4217 currency code (e.g. USD, GBP, EUR). " +
+        "Defaults to the store's base currency when omitted."
+    ),
+
+  expirationDateDays: z
+    .number()
+    .int()
+    .min(1)
+    .max(90)
+    .optional()
+    .describe(
+      "Number of days until the quote expires (1–90). Defaults to 30 when omitted. " +
+        "After expiry the quoteUrl is no longer accessible."
+    ),
+
+  fulfillmentTerm: z
+    .nativeEnum(QuoteFulfillmentTerm)
+    .optional()
+    .describe(
+      "When the quote is considered fulfilled. " +
+        "ON_PAYMENT (default): fulfilled when payment is received. " +
+        "ON_QUOTE_ACCEPTANCE: fulfilled when the buyer accepts the document before payment."
+    ),
+
+  notes: z
+    .string()
+    .max(5000)
+    .transform(trimString)
+    .optional()
+    .describe(
+      "Optional notes displayed on the quote document (max 5000 characters)."
+    ),
+
+  netTermsDays: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Net payment terms in days (e.g. 30 for Net 30). Optional."),
+
+  tags: z
+    .array(QuoteTagSchema)
+    .optional()
+    .describe(
+      "Array of {key, value} tag objects to attach to the quote. " +
+        "Useful for tracking source, sales rep, CRM deal ID, etc."
+    ),
+
+  taxId: z
+    .string()
+    .max(255)
+    .transform(trimString)
+    .optional()
+    .describe(
+      "Buyer's VAT or tax registration number (e.g. GB123456789). " +
+        "Shown on the quote/invoice and may affect tax calculation."
+    ),
+});
+
+export type CreateQuoteInput = z.infer<typeof CreateQuoteSchema>;
+
+// ---------------------------------------------------------------------------
+// Deps
+// ---------------------------------------------------------------------------
+
+export type QuotesToolsDeps = QuotesServiceDeps;
+
+// ---------------------------------------------------------------------------
+// Request mapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps validated Zod-parsed input to the FastSpring API request shape.
+ * Only includes optional fields when they are actually present, so we
+ * never send `undefined` keys to the API.
+ */
+function mapInputToRequest(input: CreateQuoteInput): CreateQuoteRequest {
+  const request: CreateQuoteRequest = {
+    name: input.name,
+    items: input.items as QuoteRequestItem[],
+    recipient: input.recipient as QuoteRecipient,
+    recipientAddress: input.recipientAddress as QuoteRecipientAddress,
+  };
+
+  if (input.coupon !== undefined) request.coupon = input.coupon;
+  if (input.currency !== undefined) request.currency = input.currency;
+  if (input.expirationDateDays !== undefined)
+    request.expirationDateDays = input.expirationDateDays;
+  if (input.fulfillmentTerm !== undefined)
+    request.fulfillmentTerm = input.fulfillmentTerm;
+  if (input.notes !== undefined) request.notes = input.notes;
+  if (input.netTermsDays !== undefined)
+    request.netTermsDays = input.netTermsDays;
+  if (input.tags !== undefined) request.tags = input.tags as QuoteTag[];
+  if (input.taxId !== undefined) request.taxId = input.taxId;
+
+  return request;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handles a create_quote tool call.
+ * Returns a JSON content block containing the key fields the caller needs:
+ * primarily `quoteUrl` (the shareable payment link) and `quoteId`.
+ */
+export async function handleCreateQuote(
+  deps: QuotesToolsDeps,
+  input: unknown
+): Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }> {
+  try {
+    const parsed = CreateQuoteSchema.parse(input);
+    const request = mapInputToRequest(parsed);
+
+    const quote = await quotesService.createQuote(deps, request);
+
+    const responsePayload = {
+      quoteId: quote.id,
+      quoteUrl: quote.quoteUrl,
+      status: quote.status,
+      name: quote.name,
+      currency: quote.currency,
+      subtotal: quote.subtotal,
+      subtotalDisplay: quote.subtotalDisplay,
+      tax: quote.tax,
+      taxRate: quote.taxRate,
+      taxType: quote.taxType,
+      total: quote.total,
+      totalDisplay: quote.totalDisplay,
+      expires: quote.expires,
+      created: quote.created,
+      recipient: quote.recipient,
+      recipientAddress: quote.recipientAddress,
+      items: quote.items,
+      tags: quote.tags,
+      orderReference: quote.orderReference,
+      fulfillmentTerm: quote.fulfillmentTerm,
+    };
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(responsePayload, null, 2),
+        },
+      ],
+    };
+  } catch (error) {
+    const message =
+      error instanceof FastSpringError
+        ? `FastSpring API error (${error.statusCode}): ${error.message}`
+        : error instanceof Error
+          ? error.message
+          : String(error);
+
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }],
+      isError: true,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+// ---------------------------------------------------------------------------
+
+export const quotesToolDefinitions = [
+  {
+    name: "create_quote",
+    description:
+      "Use this tool to create a new quote (formal order document) for one or more " +
+      "FastSpring subscription or product SKUs on behalf of a buyer. " +
+      "\n\n" +
+      "A quote is the correct way to programmatically generate a Custom Order in " +
+      "FastSpring — it is NOT a checkout session and does NOT charge the buyer. " +
+      "\n\n" +
+      "On success the tool returns a `quoteUrl` — a permanent payment link you can " +
+      "send to the buyer. The buyer opens the link, sees a full B2B quote document " +
+      "with line items, VAT/tax breakdown, and pricing, then pays on the FastSpring " +
+      "storefront at their convenience. The quote appears immediately in the " +
+      "FastSpring dashboard under Quotes and remains open until paid, cancelled, or " +
+      "expired (default 30 days, maximum 90 days). " +
+      "\n\n" +
+      "Required inputs: quote name, at least one product SKU, buyer first name, " +
+      "last name, email, and billing country (2-letter ISO code). " +
+      "\n\n" +
+      "Optional: quantity and price overrides per item, coupon code, currency, " +
+      "expiration days (1–90), fulfilment term, notes, net-terms days, tags " +
+      "(array of {key, value} objects), and buyer VAT/tax ID.",
+    description_for_model:
+      "Creates a FastSpring quote. Returns quoteUrl (permanent payment link to share " +
+      "with buyer), quoteId, status (OPEN), and full pricing summary. The buyer pays " +
+      "via the link — no payment is taken by this call.",
+    inputSchema: CreateQuoteSchema,
+    handler: handleCreateQuote,
+  },
+] as const;

--- a/src/types/quotes.types.ts
+++ b/src/types/quotes.types.ts
@@ -1,0 +1,174 @@
+/**
+ * @license
+ * This software is licensed under AGPL v3. For commercial licensing, see COMMERCIAL_LICENSE.md.
+ */
+
+/**
+ * FastSpring Quotes API types.
+ * Aligned with POST https://api.fastspring.com/quotes
+ * https://developer.fastspring.com/reference/create-a-quote
+ */
+
+/** When the quote is considered fulfilled. */
+export enum QuoteFulfillmentTerm {
+  /** Fulfilled as soon as payment is received. Use this for normal orders. */
+  ON_PAYMENT = "ON_PAYMENT",
+  /** Fulfilled when the buyer accepts the quote document (before payment). */
+  ON_QUOTE_ACCEPTANCE = "ON_QUOTE_ACCEPTANCE",
+}
+
+/** Possible statuses a quote can be in. */
+export enum QuoteStatus {
+  OPEN = "OPEN",
+  CANCELED = "CANCELED",
+  AWAITING_PAYMENT = "AWAITING_PAYMENT",
+  COMPLETED = "COMPLETED",
+  EXPIRED = "EXPIRED",
+}
+
+/** A single line item on the quote request. */
+export interface QuoteRequestItem {
+  /** Product path as configured in the FastSpring catalog (e.g. "my-annual-subscription"). */
+  product: string;
+  /** Number of units. Defaults to 1 when omitted. */
+  quantity?: number;
+  /**
+   * Override the catalogue list price per unit in the quote's base currency.
+   * When omitted, the catalogue price is used.
+   */
+  unitListPrice?: number;
+}
+
+/** Recipient (buyer) contact information. */
+export interface QuoteRecipient {
+  /** Buyer's first name (required). */
+  first: string;
+  /** Buyer's last name (required). */
+  last: string;
+  /** Buyer's email address (required). */
+  email: string;
+  /** Buyer's company name (optional). */
+  company?: string;
+  /** Buyer's phone number (optional). */
+  phone?: string;
+}
+
+/** Billing address for the quote recipient. */
+export interface QuoteRecipientAddress {
+  /** ISO 3166-1 alpha-2 country code, e.g. GB, US, DE (required). */
+  country: string;
+  /** Postal or ZIP code. May be empty string when not applicable. */
+  postalCode?: string;
+  /** First address line (optional). */
+  addressLine1?: string;
+  /** Second address line (optional). */
+  addressLine2?: string;
+  /** City (optional). */
+  city?: string;
+  /** State, province, or region (optional). */
+  region?: string;
+}
+
+/** A tag attached to a quote. Tags use an array of key-value objects (unlike orders which use a flat map). */
+export interface QuoteTag {
+  key: string;
+  value: string;
+}
+
+/**
+ * Request body for POST /quotes.
+ * Required: items, name, recipient, recipientAddress.
+ */
+export interface CreateQuoteRequest {
+  /** One or more products to include in the quote (required, min 1). */
+  items: QuoteRequestItem[];
+  /** Internal name / label for the quote — visible in the FastSpring dashboard (required). */
+  name: string;
+  /** Buyer contact information (required). */
+  recipient: QuoteRecipient;
+  /** Buyer billing address (required). country and postalCode are required by the API. */
+  recipientAddress: QuoteRecipientAddress;
+  /** Optional coupon code to apply to the quote. */
+  coupon?: string;
+  /** 3-letter ISO currency code (e.g. USD, GBP, EUR). Defaults to store currency when omitted. */
+  currency?: string;
+  /** Number of days before the quote expires (1–90). Defaults to 30. */
+  expirationDateDays?: number;
+  /** When the quote is considered fulfilled. Defaults to ON_PAYMENT. */
+  fulfillmentTerm?: QuoteFulfillmentTerm;
+  /** Optional notes shown on the quote document (max 5000 chars). */
+  notes?: string;
+  /** Net payment terms in days (e.g. 30 = Net 30). */
+  netTermsDays?: number;
+  /** Tags to attach to the quote. Array of {key, value} objects. */
+  tags?: QuoteTag[];
+  /** Buyer's VAT/tax ID (e.g. "GB123456789"). */
+  taxId?: string;
+}
+
+/** Summary of a line item in the quote response. */
+export interface QuoteResponseItem {
+  product: string;
+  display?: string;
+  quantity: number;
+  unitListPrice?: number;
+  unitListPriceDisplay?: string;
+  unitPrice?: number;
+  unitPriceDisplay?: string;
+  period?: string | null;
+  subscription?: boolean;
+  taxes?: Array<{ taxValue: number; totalTaxable: number }>;
+}
+
+/**
+ * Response from POST /quotes.
+ * The key field for callers is `quoteUrl` — the shareable payment link.
+ */
+export interface CreateQuoteResponse {
+  /** Unique quote identifier. */
+  id: string;
+  /**
+   * The shareable URL to send to the buyer.
+   * The buyer opens this link, reviews the quote with full line items and tax
+   * breakdown, then pays on the FastSpring store.
+   */
+  quoteUrl: string;
+  /** Current quote status. Will be OPEN on successful creation. */
+  status: QuoteStatus;
+  /** Quote name as set in the request. */
+  name: string;
+  /** Currency code used in the quote. */
+  currency?: string;
+  /** Subtotal before tax. */
+  subtotal?: number;
+  /** Formatted subtotal (e.g. "$89.00"). */
+  subtotalDisplay?: string;
+  /** Total tax amount. */
+  tax?: number;
+  /** Tax rate as a percentage (e.g. 20.0 for 20%). */
+  taxRate?: number;
+  /** Tax type (e.g. VAT, TAX). */
+  taxType?: string;
+  /** Total including tax. */
+  total?: number;
+  /** Formatted total (e.g. "$106.80"). */
+  totalDisplay?: string;
+  /** ISO datetime string when the quote expires. */
+  expires?: string;
+  /** ISO datetime string when the quote was created. */
+  created?: string;
+  /** Recipient information echoed back from the request. */
+  recipient?: QuoteRecipient & { userId?: string | null };
+  /** Recipient address echoed back from the request. */
+  recipientAddress?: QuoteRecipientAddress;
+  /** Line items with full pricing detail. */
+  items?: QuoteResponseItem[];
+  /** Tags attached to the quote. */
+  tags?: QuoteTag[];
+  /** Net terms days. */
+  netTermsDays?: number;
+  /** Order reference once the quote is paid and becomes an order. null until paid. */
+  orderReference?: string | null;
+  /** Fulfillment term used for this quote. */
+  fulfillmentTerm?: QuoteFulfillmentTerm;
+}

--- a/tests/services/quotes.service.test.ts
+++ b/tests/services/quotes.service.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * This software is licensed under AGPL v3. For commercial licensing, see COMMERCIAL_LICENSE.md.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import axios from "axios";
+import { createQuote } from "../../src/services/quotes.service.js";
+import type { QuotesServiceDeps } from "../../src/services/quotes.service.js";
+import { FastSpringError } from "../../src/utils/errors.js";
+import { QuoteFulfillmentTerm, QuoteStatus } from "../../src/types/quotes.types.js";
+import type { CreateQuoteRequest } from "../../src/types/quotes.types.js";
+
+vi.mock("axios");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MINIMAL_REQUEST: CreateQuoteRequest = {
+  name: "Test Quote",
+  items: [{ product: "basic-subscription" }],
+  recipient: { first: "Jane", last: "Doe", email: "jane@example.com" },
+  recipientAddress: { country: "US", postalCode: "90210" },
+};
+
+const QUOTE_RESPONSE = {
+  id: "QUXU7RGI3XVNG53EAC6QJIMK4MVA",
+  quoteUrl: "https://test.onfastspring.com/popup-defaultB2B/account/order/quote/QUXU7RGI3XVNG53EAC6QJIMK4MVA",
+  status: QuoteStatus.OPEN,
+  name: "Test Quote",
+  currency: "USD",
+  subtotal: 89.0,
+  subtotalDisplay: "$89.00",
+  tax: 0,
+  taxRate: 0,
+  taxType: "TAX",
+  total: 89.0,
+  totalDisplay: "$89.00",
+  expires: "2026-05-02T15:01:57.508+00:00",
+  created: "2026-04-02T15:01:57.652+00:00",
+  recipient: { first: "Jane", last: "Doe", email: "jane@example.com" },
+  items: [{ product: "basic-subscription", quantity: 1, unitListPrice: 89.0 }],
+  tags: [],
+  orderReference: null,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("quotes.service", () => {
+  const mockHttp = {
+    post: vi.fn(),
+  } as unknown as ReturnType<typeof axios.create>;
+
+  const deps: QuotesServiceDeps = { http: mockHttp };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  describe("createQuote", () => {
+    it("posts to /quotes and returns the quote response", async () => {
+      mockHttp.post.mockResolvedValueOnce({ data: QUOTE_RESPONSE });
+
+      const result = await createQuote(deps, MINIMAL_REQUEST);
+
+      expect(mockHttp.post).toHaveBeenCalledWith("/quotes", MINIMAL_REQUEST);
+      expect(result).toEqual(QUOTE_RESPONSE);
+    });
+
+    it("returns quoteUrl and id from the response", async () => {
+      mockHttp.post.mockResolvedValueOnce({ data: QUOTE_RESPONSE });
+
+      const result = await createQuote(deps, MINIMAL_REQUEST);
+
+      expect(result.id).toBe("QUXU7RGI3XVNG53EAC6QJIMK4MVA");
+      expect(result.quoteUrl).toContain("/popup-defaultB2B/account/order/quote/");
+    });
+
+    it("passes the full request body unchanged to the API", async () => {
+      const fullRequest: CreateQuoteRequest = {
+        name: "Enterprise Deal Q2",
+        items: [
+          { product: "pro-subscription", quantity: 5, unitListPrice: 99.0 },
+          { product: "add-on-feature", quantity: 5 },
+        ],
+        recipient: {
+          first: "Bob",
+          last: "Smith",
+          email: "bob@enterprise.com",
+          company: "Enterprise Corp",
+          phone: "+15555551234",
+        },
+        recipientAddress: {
+          country: "US",
+          postalCode: "10001",
+          city: "New York",
+          region: "NY",
+          addressLine1: "100 Main St",
+        },
+        currency: "USD",
+        expirationDateDays: 14,
+        fulfillmentTerm: QuoteFulfillmentTerm.ON_PAYMENT,
+        notes: "Please pay within 14 days.",
+        coupon: "ENTERPRISE10",
+        tags: [
+          { key: "salesRep", value: "alice" },
+          { key: "dealId", value: "crm-1234" },
+        ],
+        taxId: "US123456789",
+        netTermsDays: 14,
+      };
+      mockHttp.post.mockResolvedValueOnce({ data: QUOTE_RESPONSE });
+
+      await createQuote(deps, fullRequest);
+
+      expect(mockHttp.post).toHaveBeenCalledWith("/quotes", fullRequest);
+    });
+
+    it("passes tags as array of {key, value} objects", async () => {
+      mockHttp.post.mockResolvedValueOnce({ data: QUOTE_RESPONSE });
+
+      const request: CreateQuoteRequest = {
+        ...MINIMAL_REQUEST,
+        tags: [
+          { key: "channel", value: "direct" },
+          { key: "region", value: "emea" },
+        ],
+      };
+      await createQuote(deps, request);
+
+      const posted = mockHttp.post.mock.calls[0][1] as CreateQuoteRequest;
+      expect(posted.tags).toEqual([
+        { key: "channel", value: "direct" },
+        { key: "region", value: "emea" },
+      ]);
+    });
+
+    it("passes price override per item when unitListPrice is set", async () => {
+      mockHttp.post.mockResolvedValueOnce({ data: QUOTE_RESPONSE });
+
+      const request: CreateQuoteRequest = {
+        ...MINIMAL_REQUEST,
+        items: [{ product: "basic-subscription", quantity: 1, unitListPrice: 99.0 }],
+      };
+      await createQuote(deps, request);
+
+      const posted = mockHttp.post.mock.calls[0][1] as CreateQuoteRequest;
+      expect(posted.items[0].unitListPrice).toBe(99.0);
+    });
+
+    it("propagates FastSpringError on 400 bad request", async () => {
+      mockHttp.post.mockRejectedValueOnce(
+        new FastSpringError("Invalid product path", 400, {
+          message: "Invalid product path",
+        })
+      );
+
+      await expect(createQuote(deps, MINIMAL_REQUEST)).rejects.toThrow(FastSpringError);
+    });
+
+    it("propagates FastSpringError on 401 unauthorized", async () => {
+      mockHttp.post.mockRejectedValueOnce(new FastSpringError("Unauthorized", 401));
+
+      await expect(createQuote(deps, MINIMAL_REQUEST)).rejects.toThrow(FastSpringError);
+    });
+
+    it("propagates FastSpringError on 403 forbidden", async () => {
+      mockHttp.post.mockRejectedValueOnce(new FastSpringError("Forbidden", 403));
+
+      await expect(createQuote(deps, MINIMAL_REQUEST)).rejects.toThrow(FastSpringError);
+    });
+
+    it("propagates network errors", async () => {
+      mockHttp.post.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+      await expect(createQuote(deps, MINIMAL_REQUEST)).rejects.toThrow("ECONNREFUSED");
+    });
+
+    it("propagates timeout errors", async () => {
+      mockHttp.post.mockRejectedValueOnce(new Error("ETIMEDOUT"));
+
+      await expect(createQuote(deps, MINIMAL_REQUEST)).rejects.toThrow("ETIMEDOUT");
+    });
+  });
+});

--- a/tests/tools/quotes.tools.test.ts
+++ b/tests/tools/quotes.tools.test.ts
@@ -1,0 +1,504 @@
+/**
+ * @license
+ * This software is licensed under AGPL v3. For commercial licensing, see COMMERCIAL_LICENSE.md.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  CreateQuoteSchema,
+  handleCreateQuote,
+  quotesToolDefinitions,
+} from "../../src/tools/quotes.tools.js";
+import { FastSpringError } from "../../src/utils/errors.js";
+import { QuoteFulfillmentTerm, QuoteStatus } from "../../src/types/quotes.types.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const VALID_MINIMAL_INPUT = {
+  name: "Test Quote",
+  items: [{ product: "basic-subscription" }],
+  recipient: { first: "Jane", last: "Doe", email: "jane@example.com" },
+  recipientAddress: { country: "US" },
+};
+
+const QUOTE_RESPONSE = {
+  id: "QUXU7RGI3XVNG53EAC6QJIMK4MVA",
+  quoteUrl:
+    "https://test.onfastspring.com/popup-defaultB2B/account/order/quote/QUXU7RGI3XVNG53EAC6QJIMK4MVA",
+  status: QuoteStatus.OPEN,
+  name: "Test Quote",
+  currency: "USD",
+  subtotal: 89.0,
+  subtotalDisplay: "$89.00",
+  tax: 0,
+  taxRate: 0,
+  taxType: "TAX",
+  total: 89.0,
+  totalDisplay: "$89.00",
+  expires: "2026-05-02T15:01:57.508+00:00",
+  created: "2026-04-02T15:01:57.652+00:00",
+  recipient: { first: "Jane", last: "Doe", email: "jane@example.com" },
+  recipientAddress: { country: "US", postalCode: "" },
+  items: [{ product: "basic-subscription", quantity: 1, unitListPrice: 89.0 }],
+  tags: [],
+  orderReference: null,
+};
+
+// ---------------------------------------------------------------------------
+// Schema Validation
+// ---------------------------------------------------------------------------
+
+describe("CreateQuoteSchema", () => {
+  describe("required fields", () => {
+    it("parses minimal valid input", () => {
+      const result = CreateQuoteSchema.safeParse(VALID_MINIMAL_INPUT);
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects when name is missing", () => {
+      const { name: _, ...input } = VALID_MINIMAL_INPUT;
+      const result = CreateQuoteSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects when items is missing", () => {
+      const { items: _, ...input } = VALID_MINIMAL_INPUT;
+      const result = CreateQuoteSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects when items array is empty", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        items: [],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects when recipient is missing", () => {
+      const { recipient: _, ...input } = VALID_MINIMAL_INPUT;
+      const result = CreateQuoteSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects when recipientAddress is missing", () => {
+      const { recipientAddress: _, ...input } = VALID_MINIMAL_INPUT;
+      const result = CreateQuoteSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects when recipient.email is missing", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        recipient: { first: "Jane", last: "Doe" },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects when recipient.first is missing", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        recipient: { last: "Doe", email: "jane@example.com" },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects when recipient.last is missing", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        recipient: { first: "Jane", email: "jane@example.com" },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects when recipientAddress.country is missing", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        recipientAddress: { postalCode: "90210" },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects when item.product is missing", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        items: [{ quantity: 2 }],
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("recipient email validation", () => {
+    it("rejects an invalid email", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        recipient: { ...VALID_MINIMAL_INPUT.recipient, email: "not-an-email" },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("trims whitespace from email before validation", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        recipient: {
+          ...VALID_MINIMAL_INPUT.recipient,
+          email: "  jane@example.com  ",
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.recipient.email).toBe("jane@example.com");
+      }
+    });
+  });
+
+  describe("country code validation", () => {
+    it("rejects a country code that is not exactly 2 characters", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        recipientAddress: { country: "USA" },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a valid 2-letter country code", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        recipientAddress: { country: "GB" },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("normalises country code to uppercase", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        recipientAddress: { country: "gb" },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.recipientAddress.country).toBe("GB");
+      }
+    });
+  });
+
+  describe("optional item fields", () => {
+    it("accepts item with only product set", () => {
+      const result = CreateQuoteSchema.safeParse(VALID_MINIMAL_INPUT);
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts item with product, quantity, and unitListPrice", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        items: [{ product: "basic-subscription", quantity: 5, unitListPrice: 79.0 }],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects item quantity of 0", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        items: [{ product: "basic-subscription", quantity: 0 }],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects negative unitListPrice", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        items: [{ product: "basic-subscription", unitListPrice: -1 }],
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("optional top-level fields", () => {
+    it("accepts expirationDateDays within 1-90 range", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        expirationDateDays: 30,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects expirationDateDays of 0", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        expirationDateDays: 0,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects expirationDateDays greater than 90", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        expirationDateDays: 91,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a valid fulfillmentTerm enum value", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        fulfillmentTerm: QuoteFulfillmentTerm.ON_PAYMENT,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects an unknown fulfillmentTerm value", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        fulfillmentTerm: "INVALID_TERM",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts tags as array of {key, value} objects", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        tags: [{ key: "channel", value: "direct" }],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts a valid 3-letter currency code", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        currency: "GBP",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a currency code that is not 3 characters", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        currency: "US",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts multiple items", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        items: [
+          { product: "product-a", quantity: 1 },
+          { product: "product-b", quantity: 2, unitListPrice: 49.0 },
+        ],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("trims whitespace from name", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        name: "  My Quote  ",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.name).toBe("My Quote");
+      }
+    });
+
+    it("trims whitespace from product path", () => {
+      const result = CreateQuoteSchema.safeParse({
+        ...VALID_MINIMAL_INPUT,
+        items: [{ product: "  basic-subscription  " }],
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.items[0].product).toBe("basic-subscription");
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler Tests
+// ---------------------------------------------------------------------------
+
+describe("handleCreateQuote", () => {
+  const mockPost = vi.fn();
+  const mockDeps = {
+    http: { post: mockPost },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns structured content with quoteId and quoteUrl on success", async () => {
+    mockPost.mockResolvedValueOnce({ data: QUOTE_RESPONSE });
+
+    const result = await handleCreateQuote(mockDeps, VALID_MINIMAL_INPUT);
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.quoteId).toBe("QUXU7RGI3XVNG53EAC6QJIMK4MVA");
+    expect(parsed.quoteUrl).toContain("/popup-defaultB2B/account/order/quote/");
+  });
+
+  it("includes status OPEN in the response", async () => {
+    mockPost.mockResolvedValueOnce({ data: QUOTE_RESPONSE });
+
+    const result = await handleCreateQuote(mockDeps, VALID_MINIMAL_INPUT);
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.status).toBe(QuoteStatus.OPEN);
+  });
+
+  it("includes pricing summary fields in the response", async () => {
+    mockPost.mockResolvedValueOnce({ data: QUOTE_RESPONSE });
+
+    const result = await handleCreateQuote(mockDeps, VALID_MINIMAL_INPUT);
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.totalDisplay).toBe("$89.00");
+    expect(parsed.currency).toBe("USD");
+    expect(parsed.expires).toBeDefined();
+  });
+
+  it("maps input correctly — sends trimmed name and uppercased country to the API", async () => {
+    mockPost.mockResolvedValueOnce({ data: QUOTE_RESPONSE });
+
+    await handleCreateQuote(mockDeps, {
+      ...VALID_MINIMAL_INPUT,
+      name: "  Q2 Deal  ",
+      recipientAddress: { country: "gb" },
+    });
+
+    const postedBody = mockPost.mock.calls[0][1];
+    expect(postedBody.name).toBe("Q2 Deal");
+    expect(postedBody.recipientAddress.country).toBe("GB");
+  });
+
+  it("sends tags as array of {key, value} objects to the API", async () => {
+    mockPost.mockResolvedValueOnce({ data: QUOTE_RESPONSE });
+
+    await handleCreateQuote(mockDeps, {
+      ...VALID_MINIMAL_INPUT,
+      tags: [
+        { key: "salesRep", value: "alice" },
+        { key: "dealId", value: "crm-1234" },
+      ],
+    });
+
+    const postedBody = mockPost.mock.calls[0][1];
+    expect(postedBody.tags).toEqual([
+      { key: "salesRep", value: "alice" },
+      { key: "dealId", value: "crm-1234" },
+    ]);
+  });
+
+  it("omits tags from request body when not provided", async () => {
+    mockPost.mockResolvedValueOnce({ data: QUOTE_RESPONSE });
+
+    await handleCreateQuote(mockDeps, VALID_MINIMAL_INPUT);
+
+    const postedBody = mockPost.mock.calls[0][1];
+    expect(postedBody.tags).toBeUndefined();
+  });
+
+  it("omits optional fields from request body when not provided", async () => {
+    mockPost.mockResolvedValueOnce({ data: QUOTE_RESPONSE });
+
+    await handleCreateQuote(mockDeps, VALID_MINIMAL_INPUT);
+
+    const postedBody = mockPost.mock.calls[0][1];
+    expect(postedBody.coupon).toBeUndefined();
+    expect(postedBody.currency).toBeUndefined();
+    expect(postedBody.expirationDateDays).toBeUndefined();
+    expect(postedBody.fulfillmentTerm).toBeUndefined();
+    expect(postedBody.notes).toBeUndefined();
+    expect(postedBody.netTermsDays).toBeUndefined();
+    expect(postedBody.taxId).toBeUndefined();
+  });
+
+  it("passes through all optional fields when provided", async () => {
+    mockPost.mockResolvedValueOnce({ data: QUOTE_RESPONSE });
+
+    await handleCreateQuote(mockDeps, {
+      ...VALID_MINIMAL_INPUT,
+      coupon: "SAVE20",
+      currency: "GBP",
+      expirationDateDays: 14,
+      fulfillmentTerm: QuoteFulfillmentTerm.ON_PAYMENT,
+      notes: "Pay within 14 days",
+      netTermsDays: 14,
+      taxId: "GB123456789",
+    });
+
+    const postedBody = mockPost.mock.calls[0][1];
+    expect(postedBody.coupon).toBe("SAVE20");
+    expect(postedBody.currency).toBe("GBP");
+    expect(postedBody.expirationDateDays).toBe(14);
+    expect(postedBody.fulfillmentTerm).toBe(QuoteFulfillmentTerm.ON_PAYMENT);
+    expect(postedBody.notes).toBe("Pay within 14 days");
+    expect(postedBody.netTermsDays).toBe(14);
+    expect(postedBody.taxId).toBe("GB123456789");
+  });
+
+  describe("error handling", () => {
+    it("returns an error content block on FastSpringError", async () => {
+      mockPost.mockRejectedValueOnce(
+        new FastSpringError("Product not found", 400)
+      );
+
+      const result = await handleCreateQuote(mockDeps, VALID_MINIMAL_INPUT);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Product not found");
+    });
+
+    it("returns an error content block on generic Error", async () => {
+      mockPost.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+      const result = await handleCreateQuote(mockDeps, VALID_MINIMAL_INPUT);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("ECONNREFUSED");
+    });
+
+    it("returns a safe error message on non-Error thrown value", async () => {
+      mockPost.mockRejectedValueOnce("string error");
+
+      const result = await handleCreateQuote(mockDeps, VALID_MINIMAL_INPUT);
+
+      expect(result.isError).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool Definition Tests
+// ---------------------------------------------------------------------------
+
+describe("quotesToolDefinitions", () => {
+  it("exposes exactly one tool definition", () => {
+    expect(quotesToolDefinitions).toHaveLength(1);
+  });
+
+  it("names the tool create_quote", () => {
+    expect(quotesToolDefinitions[0].name).toBe("create_quote");
+  });
+
+  it("has a non-empty description", () => {
+    expect(quotesToolDefinitions[0].description.length).toBeGreaterThan(10);
+  });
+
+  it("description explicitly mentions quotes and payment link", () => {
+    const desc = quotesToolDefinitions[0].description.toLowerCase();
+    expect(desc).toContain("quote");
+    expect(desc).toContain("payment");
+  });
+
+  it("exposes a handler function", () => {
+    expect(typeof quotesToolDefinitions[0].handler).toBe("function");
+  });
+
+  it("exposes an inputSchema", () => {
+    expect(quotesToolDefinitions[0].inputSchema).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **New `create_quote` MCP tool** — the correct programmatic equivalent of creating a Custom Order in the FastSpring dashboard. Uses `POST /quotes`, persists immediately, appears in the FastSpring Quotes tab, and returns a `quoteUrl` the seller shares with the buyer to complete payment on the storefront. No payment is taken at creation time.
- **Fixed Zod → JSON Schema serialisation** — `ZodArray` was previously serialised as `{ type: "array" }` with no item schema, causing MCP clients to receive no information about nested item fields (e.g. `unitListPrice`). Rewrote the helpers with a proper `unwrap()` loop and added `ZodNativeEnum` / `ZodEnum` support. This fix applies to all existing tools, not just quotes.
- **58 new tests** (10 service + 48 tool), 100% coverage on `quotes.tools.ts`, all 268 tests green.

## New files

| File | Purpose |
|---|---|
| `src/types/quotes.types.ts` | TypeScript interfaces and enums for the Quotes API |
| `src/services/quotes.service.ts` | Thin `createQuote(deps, request)` wrapper around `POST /quotes` |
| `src/tools/quotes.tools.ts` | MCP tool definition, Zod schema, and handler |
| `tests/services/quotes.service.test.ts` | Service unit tests |
| `tests/tools/quotes.tools.test.ts` | Tool unit tests (schema validation, handler, error paths) |

## Changed files

| File | Change |
|---|---|
| `src/index.ts` | Wire `quotesToolDefinitions` into server; rewrite Zod → JSON Schema helpers |

## Tool inputs

**Required:** `name`, `items[].product`, `recipient.first/last/email`, `recipientAddress.country` (2-letter ISO)

**Optional:** `items[].quantity`, `items[].unitListPrice`, `coupon`, `currency`, `expirationDateDays` (1–90), `fulfillmentTerm` (`ON_PAYMENT` | `ON_QUOTE_ACCEPTANCE`), `notes`, `netTermsDays`, `tags` (`{key,value}[]`), `taxId`

## Test plan

- [ ] Call `create_quote` with required fields only — verify `quoteUrl` returned and quote visible in FastSpring dashboard under Quotes
- [ ] Call with `unitListPrice` override — verify FastSpring reflects the custom price
- [ ] Call with `expirationDateDays: 91` — verify Zod rejects with validation error before hitting the API
- [ ] Call with invalid email — verify Zod rejects with clear error message
- [ ] Confirm all existing tools still work correctly (JSON schema fix is non-breaking)

Made with [Cursor](https://cursor.com)